### PR TITLE
ChainSecurity audit fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build
 
 all    :  build
-build  :; DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=1000000 dapp --use solc:0.8.9 build
+build  :; DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=1000000 dapp --use solc:0.8.11 build
 clean  :; dapp clean
 test   :  build
 	./test.sh $(MATCH)

--- a/src/CurveLPOracle.sol
+++ b/src/CurveLPOracle.sol
@@ -161,6 +161,7 @@ contract CurveLPOracle {
         return block.timestamp >= zph;
     }
 
+    // Marked payable to save gas. DO *NOT* send ETH to poke(), it will be lost permanently.
     function poke() external payable {
 
         // Ensure a single SLOAD while avoiding solc's excessive bitmasking bureaucracy.

--- a/src/CurveLPOracle.sol
+++ b/src/CurveLPOracle.sol
@@ -132,7 +132,11 @@ contract CurveLPOracle {
     }
 
     function step(uint16 _hop) external auth {
+        uint16 old = hop;
         hop = _hop;
+        if (zph >= old) {  // if false, zph will be unset and no update is needed
+            zph = (zph - old) + _hop;
+        }
         emit Step(_hop);
     }
 

--- a/src/CurveLPOracle.sol
+++ b/src/CurveLPOracle.sol
@@ -52,7 +52,7 @@ contract CurveLPOracleFactory {
         bytes32 _wat,
         address[] calldata _orbs
     ) external returns (address orcl) {
-        uint256 ncoins = CurveRegistryLike(ADDRESS_PROVIDER.get_registry()).get_n_coins(_pool)[0];
+        uint256 ncoins = CurveRegistryLike(ADDRESS_PROVIDER.get_registry()).get_n_coins(_pool)[1];
         require(ncoins == _orbs.length, "CurveLPOracleFactory/wrong-num-of-orbs");
         orcl = address(new CurveLPOracle(_owner, _pool, _wat, _orbs));
         emit NewCurveLPOracle(_owner, orcl, _wat, _pool);

--- a/src/CurveLPOracle.sol
+++ b/src/CurveLPOracle.sol
@@ -161,7 +161,7 @@ contract CurveLPOracle {
         return block.timestamp >= zph;
     }
 
-    function poke() external {
+    function poke() external payable {
 
         // Ensure a single SLOAD while avoiding solc's excessive bitmasking bureaucracy.
         uint256 hop_;

--- a/src/CurveLPOracle.sol
+++ b/src/CurveLPOracle.sol
@@ -81,8 +81,8 @@ contract CurveLPOracle {
         uint128 has;  // Is price valid
     }
 
-    Feed internal cur;  // Current price (mem slot 0x3)
-    Feed internal nxt;  // Queued price  (mem slot 0x4)
+    Feed internal cur;  // Current price (storage slot 0x3)
+    Feed internal nxt;  // Queued price  (storage slot 0x4)
 
     address[] public orbs;  // array of price feeds for pool assets, same order as in the pool
 

--- a/src/CurveLPOracle.sol
+++ b/src/CurveLPOracle.sol
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.11;
 
 interface CurveRegistryLike {
     function get_n_coins(address) external view returns (uint256[2] calldata);

--- a/src/CurveLPOracle.sol
+++ b/src/CurveLPOracle.sol
@@ -131,9 +131,8 @@ contract CurveLPOracle {
         emit Start();
     }
 
-    function step(uint256 _hop) external auth {
-        require(_hop <= type(uint16).max, "CurveLPOracle/invalid-hop");
-        hop = uint16(_hop);
+    function step(uint16 _hop) external auth {
+        hop = _hop;
         emit Step(_hop);
     }
 

--- a/src/CurveLPOracle.sol
+++ b/src/CurveLPOracle.sol
@@ -138,7 +138,7 @@ contract CurveLPOracle {
     function step(uint16 _hop) external auth {
         uint16 old = hop;
         hop = _hop;
-        if (zph >= old) {  // if false, zph will be unset and no update is needed
+        if (zph > old) {  // if false, zph will be unset and no update is needed
             zph = (zph - old) + _hop;
         }
         emit Step(_hop);

--- a/src/CurveLPOracle.sol
+++ b/src/CurveLPOracle.sol
@@ -19,6 +19,10 @@
 
 pragma solidity 0.8.11;
 
+interface AddressProviderLike {
+    function get_registry() external view returns (address);
+}
+
 interface CurveRegistryLike {
     function get_n_coins(address) external view returns (uint256[2] calldata);
 }
@@ -34,12 +38,12 @@ interface OracleLike {
 
 contract CurveLPOracleFactory {
 
-    CurveRegistryLike immutable REGISTRY;
+    AddressProviderLike immutable ADDRESS_PROVIDER;
 
     event NewCurveLPOracle(address owner, address orcl, bytes32 wat, address pool);
 
-    constructor(address _registry) {
-        REGISTRY = CurveRegistryLike(_registry);
+    constructor(address addressProvider) {
+        ADDRESS_PROVIDER = AddressProviderLike(addressProvider);
     }
 
     function build(
@@ -48,7 +52,7 @@ contract CurveLPOracleFactory {
         bytes32 _wat,
         address[] calldata _orbs
     ) external returns (address orcl) {
-        uint256 ncoins = REGISTRY.get_n_coins(_pool)[0];
+        uint256 ncoins = CurveRegistryLike(ADDRESS_PROVIDER.get_registry()).get_n_coins(_pool)[0];
         require(ncoins == _orbs.length, "CurveLPOracleFactory/wrong-num-of-orbs");
         orcl = address(new CurveLPOracle(_owner, _pool, _wat, _orbs));
         emit NewCurveLPOracle(_owner, orcl, _wat, _pool);

--- a/src/CurveLPOracle.t.sol
+++ b/src/CurveLPOracle.t.sol
@@ -130,6 +130,16 @@ contract CurveLPOracleTest is DSTest {
         assertEq(oracle.hop(), newHop);
         assertEq(oracle.zph(), 0);  // unset, so no change
         assertEq(oracle.zzz(), 0);
+
+        oracle.step(0);
+        assertEq(oracle.hop(), 0);
+        assertEq(oracle.zph(), 0);  // unset, so no change
+        assertEq(oracle.zzz(), 0);
+
+        oracle.step(1);  // 1 != 0
+        assertEq(oracle.hop(), 1);
+        assertEq(oracle.zph(), 0);  // unset, so no change
+        assertEq(oracle.zzz(), 0);
     }
 
     function test_stop() public {

--- a/src/CurveLPOracle.t.sol
+++ b/src/CurveLPOracle.t.sol
@@ -44,7 +44,7 @@ contract MockOracle {
 
 contract CurveLPOracleTest is DSTest {
     uint256 constant WAD = 10**18;
-    uint256 constant DEFAULT_HOP = 3600;  // 1 hour in seconds
+    uint16  constant DEFAULT_HOP = 3600;  // 1 hour in seconds
 
     Hevm hevm;
     MockCurvePool pool;

--- a/src/CurveLPOracle.t.sol
+++ b/src/CurveLPOracle.t.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.11;
 
 import "ds-test/test.sol";
 

--- a/src/CurveLPOracleFactory.t.sol
+++ b/src/CurveLPOracleFactory.t.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.11;
 
 import "ds-test/test.sol";
 

--- a/src/CurveLPOracleFactory.t.sol
+++ b/src/CurveLPOracleFactory.t.sol
@@ -37,8 +37,8 @@ contract MockCurveRegistry {
         ncoins[_pool] = _ncoins;
     }
     function get_n_coins(address _pool) external view returns (uint256[2] memory ncoins_) {
-        ncoins_[0] = ncoins[_pool];
-        ncoins_[1] = 42;  // return nonsense value so it's obvious if this is accessed when it shouldn't be
+        ncoins_[0] = 42;  // return nonsense value so it's obvious if this is accessed when it shouldn't be
+        ncoins_[1] = ncoins[_pool];
     }
 }
 

--- a/src/CurveLPOracleFactory.t.sol
+++ b/src/CurveLPOracleFactory.t.sol
@@ -21,6 +21,16 @@ import "ds-test/test.sol";
 
 import "./CurveLPOracle.sol";
 
+contract MockAddressProvider {
+    address immutable REGISTRY;
+    constructor(address registry) {
+        REGISTRY = registry;
+    }
+    function get_registry() external view returns (address) {
+        return REGISTRY;
+    }
+}
+
 contract MockCurveRegistry {
     mapping (address => uint256) ncoins;
     function addPool(address _pool, uint256 _ncoins) external {
@@ -40,7 +50,8 @@ contract CurveLPOracleFactoryTest is DSTest {
     function setUp() public {
         registry = new MockCurveRegistry();
         registry.addPool(address(0x9001), 3);
-        factory = new CurveLPOracleFactory(address(registry));
+        MockAddressProvider addressProvider = new MockAddressProvider(address(registry));
+        factory = new CurveLPOracleFactory(address(addressProvider));
         orbs.push(address(0x1));
         orbs.push(address(0x2));
         orbs.push(address(0x3));

--- a/src/StethPrice.sol
+++ b/src/StethPrice.sol
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.11;
 
 interface OracleLike {
     function peek() external view returns (uint256, bool);

--- a/src/StethPrice.t.sol
+++ b/src/StethPrice.t.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.11;
 
 import "ds-test/test.sol";
 

--- a/src/steCRV.t.sol
+++ b/src/steCRV.t.sol
@@ -38,9 +38,9 @@ contract MockOracle {
 contract ETHstETHPoolTest is DSTest {
 
     uint256 constant WAD = 10**18;
-    address constant REGISTRY   = 0x7D86446dDb609eD0F5f8684AcF30380a356b2B4c;
-    address constant POOL       = 0xDC24316b9AE028F1497c275EB9192a3Ea0f67022;
-    address constant ETH_ORACLE = 0x64DE91F5A373Cd4c28de3600cB34C7C6cE410C85;
+    address constant ADDRESS_PROVIDER = 0x0000000022D53366457F9d5E68Ec105046FC4383;
+    address constant POOL             = 0xDC24316b9AE028F1497c275EB9192a3Ea0f67022;
+    address constant ETH_ORACLE       = 0x64DE91F5A373Cd4c28de3600cB34C7C6cE410C85;
 
     Hevm hevm;
     CurveLPOracleFactory factory;
@@ -49,7 +49,7 @@ contract ETHstETHPoolTest is DSTest {
 
     function setUp() public {
         hevm = Hevm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
-        factory = new CurveLPOracleFactory(REGISTRY);
+        factory = new CurveLPOracleFactory(ADDRESS_PROVIDER);
         orbs.push(ETH_ORACLE);
         orbs.push(address(new MockOracle()));
         oracle  = CurveLPOracle(factory.build(address(this), POOL, "steCRV", orbs));

--- a/src/steCRV.t.sol
+++ b/src/steCRV.t.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.11;
 
 import "ds-test/test.sol";
 


### PR DESCRIPTION
For the most part, reviewers should be able to go commit-by-commit, except in the case of the `zph` update fix, for which I later realized an edge case that needed to be fixed, so it has two associated commits (f9f3e79 and 79a5277).